### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Inherit the community-hub-release-parent POM inside your project like so:
 <parent>
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0</version>    
+    <relativePath />
 </parent>  
 ```


### PR DESCRIPTION
Add relative path to look up in repository.

See https://robintegg.com/2019/01/20/why-does-spring-initializr-set-the-parent-pom-relativepath-to-empty.html 
We do it as well here https://github.com/camunda-community-hub/community-hub-release-parent/blob/master/pom.xml#L20