### PR TITLE
Add autorelease execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
                                     <nexusUrl>${central.staging.deploy.url}</nexusUrl>
                                     <skipStaging>true</skipStaging>
                                     <skipNexusStagingDeployMojo>${skip.central.release}</skipNexusStagingDeployMojo>
+                                    <autoReleaseAfterClose>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
                                     <nexusUrl>${central.staging.deploy.url}</nexusUrl>
                                     <skipStaging>true</skipStaging>
                                     <skipNexusStagingDeployMojo>${skip.central.release}</skipNexusStagingDeployMojo>
-                                    <autoReleaseAfterClose>
+                                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -143,13 +143,15 @@
                                     <goal>deploy</goal>
                                 </goals>
                                 <configuration>
-                                    <altStagingDirectory>${session.executionRootDirectory}/target/central-staging</altStagingDirectory>
+                                    <serverId>${camunda-hub-server-id}</serverId>
+                                    <nexusUrl>${camunda-hub-nexus-url}</nexusUrl>
+                                    <skipStagingRepositoryClose>false</skipStagingRepositoryClose>
+                                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
                                     <detectBuildFailures>true</detectBuildFailures>
-                                    <serverId>${central.staging.deploy.id}</serverId>
-                                    <nexusUrl>${central.staging.deploy.url}</nexusUrl>
-                                    <skipStaging>true</skipStaging>
-                                    <skipNexusStagingDeployMojo>${skip.central.release}</skipNexusStagingDeployMojo>
-                                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                                    <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
+                                    <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
+                                    <skipStaging>false</skipStaging>
+                                    <skipNexusStagingDeployMojo>${camunda-hub-skip-staging}</skipNexusStagingDeployMojo>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -143,15 +143,15 @@
                                     <goal>deploy</goal>
                                 </goals>
                                 <configuration>
-                                    <serverId>${camunda-hub-server-id}</serverId>
-                                    <nexusUrl>${camunda-hub-nexus-url}</nexusUrl>
                                     <skipStagingRepositoryClose>false</skipStagingRepositoryClose>
                                     <autoReleaseAfterClose>false</autoReleaseAfterClose>
                                     <detectBuildFailures>true</detectBuildFailures>
-                                    <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
-                                    <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
+                                    <serverId>${central.staging.deploy.id}</serverId>
+                                    <nexusUrl>${central.staging.deploy.url}</nexusUrl>
+                                    <stagingRepositoryId>central</stagingRepositoryId>
+                                    <altStagingDirectory>${session.executionRootDirectory}/target/central-staging</altStagingDirectory>
+                                    <skipNexusStagingDeployMojo>${skip.central.release}</skipNexusStagingDeployMojo>
                                     <skipStaging>false</skipStaging>
-                                    <skipNexusStagingDeployMojo>${camunda-hub-skip-staging}</skipNexusStagingDeployMojo>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This PR adds the `autoReleaseAfterClose` execution to Community Hub Release Parent POM file for Community Action Maven Release.

* Ref: https://github.com/camunda-community-hub/community-action-maven-release/issues/33

* Reason for proposed change: @npepinpe  had suggested adding this execution: "We use the community maven release action in https://github.com/camunda-cloud/zeebe-process-test - I just performed a release, and I can see the staging repository in Nexus. However, the workflow is done now, and the release is "finished", but the staging repository is still open. I would expect it to be closed, however, to indicate it's now safe to release. Is there a reason why it's left open? Do we need to do or configure something extra?"

