### PR TITLE
fix: Include the manifest in the JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.5</version>
+                    <configuration>
+                        <useDefaultManifestFile>true</useDefaultManifestFile>
+                        <archive>
+                            <manifest>
+                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            </manifest>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description

Configure the maven-jar-plugin to generate a manifest file and include it in the JAR.

This configuration was previously inherited from the `camunda-release-parent` pom.

Closes #24 