### PR TITLE
Update maven-jar-plugin to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,12 @@
                     <!-- Pin version down to 2.5 to be able to run on JDK 17 -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.3.0</version>
                     <configuration>
-                        <useDefaultManifestFile>true</useDefaultManifestFile>
                         <archive>
                             <manifest>
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                             </manifest>
                         </archive>
                     </configuration>


### PR DESCRIPTION
The currently used version will be deprecated in maven 4.

Can we bump it to 3.3.0 now?