### PR TITLE
feat: add central-sonatype-publish profile for Sonatype Central Portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 # Camunda Community Hub Release Parent
 
-
-Use this parent POM to do releases via the  [Community Hub Maven release action](https://github.com/camunda-community-hub/community-action-maven-release) to:
+Use this parent POM to do releases via the [Community Hub Maven release action](https://github.com/camunda-community-hub/community-action-maven-release) to:
 
 - [Camunda Artifactory](https://artifacts.camunda.com/)
-- [Sonatype](https://oss.sonatype.org/#stagingRepositories) (aka Maven Central)
+- [Maven Central](https://central.sonatype.com/publishing/deployments)
 
-See [Camunda Community Hub release documentation](https://github.com/camunda-community-hub/community/blob/main/RELEASE.MD) for more info on this.
+See [Camunda Community Hub release documentation](https://github.com/camunda-community-hub/community/blob/main/maintainers-reviewers/RELEASE.MD) for more info on this.
 
 
-# Usage
+## Usage
 
-In your pom.xml, add a parent:
-```
+In your pom.xml, add a parent using the [newest version available of this POM](https://maven-badges.herokuapp.com/maven-central/org.camunda.community/community-hub-release-parent):
+
+```xml
 <parent>
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
-    <version>1.4.3</version>    
+    <version><!-- Use the newest version available! --></version>
     <relativePath />
-</parent>  
+</parent>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,33 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>warn-deprecated-profile</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <evaluateBeanshell>
+                                            <condition>false</condition>
+                                            <message>
+⚠️ Deprecated Profile Notice: The oss-maven-central profile is deprecated and will be removed in a future release.
+
+A new profile, central-sonatype-publish, is available for use with the new Central Portal publishing interface.
+Please refer to the documentation for migration guidance:
+https://github.com/camunda-community-hub/community/blob/main/maintainers-reviewers/RELEASE.MD#migration-to-sonatype-central-portal--how-to
+                                            </message>
+                                        </evaluateBeanshell>
+                                    </rules>
+                                    <fail>false</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
             <!-- This part overwrites the default distribution management pointing to Camunda Artifactory -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
 
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
-    <version>1.4.5-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Camunda Community Hub - Release Parent Pom</name>
 
     <description>
-        This pom defines the required plugins and profiles to allow a camunda community hub release build.
-        Inherit this pom when you want to use the camunda community hub GitHub release action.
+        This POM defines the required plugins and profiles to allow a Camunda Community Hub release build.
+        Inherit this POM when you want to use https://github.com/camunda-community-hub/community-action-maven-release
     </description>
 
     <properties>
@@ -157,6 +157,11 @@
                     <version>1.6.13</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.7.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.4.1</version>
@@ -243,6 +248,41 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <!--
+            This profile configures environment for the publication using the central publishing plugin
+            into Maven Central Publisher Portal via https://central.sonatype.org/publish/publish-portal-maven/
+            -->
+            <id>central-sonatype-publish</id>
+            <properties>
+                <serverId>central</serverId>
+                <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <autoPublish>${autoReleaseAfterClose}</autoPublish>
+                            <deploymentName>${deploymentName}</deploymentName>
+                            <publishingServerId>${serverId}</publishingServerId>
+                            <skipPublishing>${skip.central.release}</skipPublishing>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <!-- This part overwrites the default distribution management pointing to Camunda Artifactory -->
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>${serverId}</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+                </snapshotRepository>
+            </distributionManagement>
         </profile>
 
         <profile>


### PR DESCRIPTION
Related  to https://github.com/camunda/team-infrastructure/issues/833. 

This PR introduces a new `central-sonatype-publish` Maven profile, intended for deploying artifacts via the Sonatype Central Portal as part of the upcoming migration from OSSRH. Additionally, a deprecation warning has been added for the existing oss-maven-central profile. This warning includes a link to relevant documentation to help users understand the change.

