### PR TITLE
chore: require explicit deprecation acknowledgment for oss-maven-central profile when deploying to io.zeebe namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,33 @@ https://github.com/camunda-community-hub/community/blob/main/maintainers-reviewe
                                     <fail>false</fail>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>fail-deprecated-profile-zeebe-no-ackn</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <evaluateBeanshell>
+                                            <condition><![CDATA[
+                                                !"${project.groupId}".startsWith("io.zeebe") ||
+                                                "${oss-maven-central.acknowledge.deprecation}".equals("true")
+                                                ]]>
+                                            </condition>
+                                            <message>
+❌ Deployment Blocked: Publishing under the io.zeebe namespace using the deprecated oss-maven-central profile is no longer supported.
+To deploy to Maven Central, please use the central-sonatype-publish profile, which supports the new Central Portal publishing interface.
+
+🛑 To bypass this check (not recommended), you may pass -Doss-maven-central.acknowledge.deprecation=true.
+
+Please refer to the documentation for migration guidance and namespace-specific rollout details:
+https://github.com/camunda-community-hub/community/blob/main/maintainers-reviewers/RELEASE.MD#migration-to-sonatype-central-portal--how-to
+                                            </message>
+                                        </evaluateBeanshell>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

Fails the build if the deprecated `oss-maven-central` profile is used to deploy to the `io.zeebe` namespace. To proceed anyway, users must explicitly acknowledge the deprecation by setting:
```
-Doss-maven-central.acknowledge.deprecation=true
```

This ensures teams are aware of the required switch to the `central-sonatype-publish` profile once the `io.zeebe` namespace is migrated to the Sonatype Central Portal.

> **Note:** This PR should be merged only after the `io.zeebe` namespace migration is complete.