### PR TITLE
chore: use @v2 tag of camunda-community-hub/community-action-maven-release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,12 +31,16 @@ jobs:
 
     - name: Deploy SNAPSHOT / Release
       id: release
-      uses: camunda-community-hub/community-action-maven-release@main
+      uses: camunda-community-hub/community-action-maven-release@v2
       with:
         release-version: ${{ github.event.release.tag_name }}
         release-profile: community-action-maven-release
         nexus-usr: ${{ secrets.NEXUS_USR }}
         nexus-psw: ${{ secrets.NEXUS_PSW }}
+        sonatype-central-portal-usr: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_CP_USR }}
+        sonatype-central-portal-psw: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_CP_PSW }}
+        # maven-usr, maven-psw and maven-url are deprecated; they are required only for publishing to the legacy OSS Sonatype repository.
+        # Once the io.zeebe namespace is migrated to the Sonatype Central Portal, these can be safely removed.
         maven-usr: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_OSS_USR }}
         maven-psw: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_OSS_PSW }}
         maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

 Use @v2 tag of `camunda-community-hub/community-action-maven-release` composite action, and using new inputs.