### PR TITLE
chore: update parent POM in sync with migration to Sonatype Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
             <id>oss-maven-central</id>
             <properties>
                 <serverId>central</serverId>
-                <nexusUrl>https://oss.sonatype.org/</nexusUrl> <!-- This is just the default, overwritten by action as some artifacts go to s01.oss...-->
+                <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl> <!-- This is just the default, overwritten by action as some artifacts go to s01.oss...-->
                 <central.staging.deploy.id>${serverId}</central.staging.deploy.id>
                 <central.staging.deploy.url>${nexusUrl}</central.staging.deploy.url>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <nexus.staging.deploy.id>camunda-nexus</nexus.staging.deploy.id>
         <nexus.staging.deploy.url>https://artifacts.camunda.com/artifactory</nexus.staging.deploy.url>
 
-        <nexus.sonatype.url>https://oss.sonatype.org</nexus.sonatype.url>
         <autoReleaseAfterClose>true</autoReleaseAfterClose>
     </properties>
 


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR introduces several updates post migration:
-  update `oss-maven-central` profile to use Central Portal OSSRH staging API, partial reimplementation of the legacy API
- removed unused `nexus.sonatype.url` property
- update deprecation warning to require explicit acknowledgment when using `oss-maven-central profile will be added in a separate PR (first test release after migration)
    - https://github.com/camunda-community-hub/community-hub-release-parent/pull/68