### PR TITLE
Improvements following the Migration to Sonatype Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <autoPublish>${autoReleaseAfterClose}</autoPublish>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <autoPublish>${autoReleaseAfterClose}</autoPublish>
+                            <checksums>required</checksums>
                             <deploymentName>${deploymentName}</deploymentName>
                             <publishingServerId>${serverId}</publishingServerId>
                             <skipPublishing>${skip.central.release}</skipPublishing>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,15 @@
             <id>central-sonatype-publish</id>
             <properties>
                 <serverId>central</serverId>
+                <!-- 
+                deploymentName is redundant with central.sonatype.deployment.name but is kept for backward compatibility.
+                -->
                 <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
+                <!-- 
+                If central.sonatype.deployment.name is set, it always takes precedence over deploymentName.
+                This is the property that child POMs inheriting from this POM should use to override the deployment name in the Sonatype Central Portal.
+                -->
+                <central.sonatype.deployment.name>${deploymentName}</central.sonatype.deployment.name>               
             </properties>
             <build>
                 <plugins>
@@ -269,7 +277,7 @@
                         <configuration>
                             <autoPublish>${autoReleaseAfterClose}</autoPublish>
                             <checksums>required</checksums>
-                            <deploymentName>${deploymentName}</deploymentName>
+                            <deploymentName>${central.sonatype.deployment.name}</deploymentName>
                             <publishingServerId>${serverId}</publishingServerId>
                             <skipPublishing>${skip.central.release}</skipPublishing>
                         </configuration>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR updates the POM as following:
- upgrade `central-publishing-maven-plugin `to 0.8.0
- generate only required checksums (md5 & sha1)
- introduce a new  `central.sonatype.deployment.name` property (similar to https://github.com/camunda/camunda-release-parent/pull/59)